### PR TITLE
Update color scheme from green to pink and add background/foreground colors

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,9 +3,17 @@
   "theme": "mint",
   "name": "Human",
   "colors": {
-    "primary": "#16A34A",
-    "light": "#07C983",
-    "dark": "#15803D"
+    "primary": "#FD366E",
+    "light": "#FF5A8A",
+    "dark": "#E5195A",
+    "background": {
+      "dark": "#18181B",
+      "light": "#FAFAFA"
+    },
+    "foreground": {
+      "dark": "#FAFAFA",
+      "light": "#18181B"
+    }
   },
   "favicon": "/favicon.svg",
   "navigation": {


### PR DESCRIPTION
### TL;DR

Updated the color scheme in docs.json from green to pink/red and added background/foreground color definitions.

### What changed?

- Changed primary color from `#16A34A` (green) to `#FD366E` (pink/red)
- Changed light color from `#07C983` to `#FF5A8A`
- Changed dark color from `#15803D` to `#E5195A`
- Added new background color definitions for dark (`#18181B`) and light (`#FAFAFA`) modes
- Added new foreground color definitions for dark (`#FAFAFA`) and light (`#18181B`) modes

### How to test?

1. Build the documentation site
2. Verify the new color scheme is applied correctly
3. Check that the site renders properly in both light and dark modes
4. Ensure all UI elements using the primary/light/dark colors display the new pink/red palette

### Why make this change?

This change updates the documentation site's branding colors to align with a new visual identity. The addition of explicit background and foreground colors for dark/light modes improves the site's accessibility and provides better control over the theme appearance in different display modes.